### PR TITLE
feat: private datasets saved to `.syftbox/private_datasets` for enhanced privacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,8 +68,9 @@ instance/
 # Scrapy stuff:
 .scrapy
 
-# Sphinx documentation
+# documentation
 docs/_build/
+docs/plans
 
 # PyBuilder
 .pybuilder/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0] - 2025-11-07
+
+### 🔒 BREAKING CHANGES
+
+Private datasets are now stored in `~/.syftbox/private_datasets/` to ensure they are **NEVER synced** to the SyftBox relay server. This provides true client-side privacy with architectural guarantees.
+
+**Migration Required**: Existing datasets from v0.4.x must be recreated. See the [Migration Guide](./README.md#migration-from-v04x) in the README.
+
+### Changed
+
+- **Private dataset storage location** moved from `~/SyftBox/datasites/<email>/private/datasets/` to `~/.syftbox/private_datasets/<email>/<dataset-name>/`
+
+  - Private datasets are now stored outside the `datasites/` folder and will NOT be synced
+  - Provides true client-side privacy - data never leaves your machine
+  - No dependency on server-side ACL enforcement
+
+- **Dataset URL structure** updated to reflect new storage locations
+  - Private: `syft://<email>/.syftbox/private_datasets/<email>/<dataset-name>`
+  - Mock (unchanged): `syft://<email>/public/datasets/<dataset-name>`
+
+### Added
+
+- **Legacy cleanup** - Automatically removes old v0.4.x private datasets when deleting datasets
+
+  - Warning message displayed when old data is found and removed
+  - Ensures users don't have duplicate private data in old synced location
+
+- **Integration tests** - New comprehensive tests for private dataset path structure
+  - Verifies private datasets are outside `datasites/` folder
+  - Confirms path isolation between private and mock datasets
+  - Tests URL format correctness
+  - Validates multi-user path isolation
+
+### Fixed
+
+- Fixed circular import issue in `dataset_models.py`
+- Fixed URL generation to not append source file paths to dataset URLs
+
+## [0.4.2] - 2025-11-06
+
+### Changed
+
+- Removed force recreate keys logic from RDS client
+- Updated packages and dependencies
+- Refactored UV runtime environment handling
+
+[0.5.0]: https://github.com/OpenMined/syft-rds/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/OpenMined/syft-rds/releases/tag/v0.4.2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,45 @@ Then open `notebooks/quickstart/full_flow.ipynb` and run through the cells.
 5. **Data Owner** shares the results
 6. **Data Scientist** views the output
 
+## Private Dataset Storage
+
+### Storage Locations
+
+**Private datasets** are stored in `~/.syftbox/private_datasets/<email>/<dataset-name>/` and are **NEVER synced** to the SyftBox relay server. This ensures true client-side privacy - your private data never leaves your machine.
+
+**Mock (public) datasets** are stored in `~/SyftBox/datasites/<email>/public/datasets/` and **ARE synced** to the relay server, allowing other users to explore your dataset structure and submit job requests.
+
+```
+~/.syftbox/
+  private_datasets/
+    your-email@example.com/
+      my-dataset/           # Your private data (NEVER synced anywhere)
+        data.csv
+        ...
+
+~/SyftBox/
+  datasites/
+    your-email@example.com/
+      public/
+        datasets/
+          my-dataset/         # Your mock data (synced to the SyftBox server and other datasites)
+            mock_data.csv
+            README.md
+```
+
+### Migration from v0.4.x
+
+⚠️ **BREAKING CHANGE in syft-rds v0.5.0**
+
+If you have existing datasets created with syft-rds v0.4.x, you'll need to recreate them:
+
+1. Note your existing dataset names
+2. Upgrade to syft-rds v0.5.0+
+3. Re-create datasets using the same private data source
+4. The new version will automatically use the new location
+
+Old private data in `datasites/<email>/private/` will not interfere and will be automatically cleaned up when you delete the datasets.
+
 ## Development
 
 ### Running Tests

--- a/src/syft_rds/client/local_stores/dataset/constants.py
+++ b/src/syft_rds/client/local_stores/dataset/constants.py
@@ -1,4 +1,7 @@
 # Constants for path segments to avoid magic strings
 DIRECTORY_PUBLIC = "public"
-DIRECTORY_PRIVATE = "private"
 DIRECTORY_DATASETS = "datasets"
+
+# Private datasets storage (outside datasites to prevent sync)
+DIRECTORY_PRIVATE_DATASETS_ROOT = ".syftbox"
+DIRECTORY_PRIVATE_DATASETS = "private_datasets"

--- a/src/syft_rds/client/local_stores/dataset/managers/files.py
+++ b/src/syft_rds/client/local_stores/dataset/managers/files.py
@@ -119,10 +119,22 @@ class DatasetFilesManager:
         dataset_name: str,
         path: Union[str, Path],
     ) -> Path:
-        """Copy private data to the private SyftBox directory."""
+        """Copy private data to non-synced SyftBox directory.
+
+        This copies the user's private dataset files to ~/.syftbox/private_datasets/
+        which is outside the datasites folder and will NOT be synced to the server.
+
+        Args:
+            dataset_name: Name of the dataset
+            path: Source path containing private data files
+
+        Returns:
+            Path to the copied private dataset directory
+        """
         private_dataset_dir: Path = self._path_manager.get_local_private_dataset_dir(
             dataset_name
         )
+        logger.info(f"Copying private dataset files to {private_dataset_dir}")
         return self.copy_directory(path, private_dataset_dir)
 
     def copy_description_file_to_public_syftbox_dir(

--- a/src/syft_rds/client/local_stores/dataset/managers/files.py
+++ b/src/syft_rds/client/local_stores/dataset/managers/files.py
@@ -181,6 +181,24 @@ class DatasetFilesManager:
 
             self._safe_remove_directory(public_dir)
             self._safe_remove_directory(private_dir)
+
+            # TODO(v0.6.0): Remove this legacy cleanup code after users have migrated
+            # Clean up old private dataset location from v0.4.x
+            # Old path: ~/SyftBox/datasites/<email>/private/datasets/<name>
+            legacy_private_dir = (
+                self._path_manager.syftbox_client.my_datasite
+                / "private"
+                / "datasets"
+                / name
+            )
+            if legacy_private_dir.exists():
+                logger.warning(
+                    f"Found dataset in legacy location (v0.4.x): {legacy_private_dir}. "
+                    f"Cleaning up old data. Please recreate datasets with v0.5.0+ "
+                    f"to use the new Syft datasets structure."
+                )
+                self._safe_remove_directory(legacy_private_dir)
+
         except Exception as e:
             logger.error(f"Failed to cleanup dataset files: {str(e)}")
             raise RuntimeError(f"Failed to clean up dataset '{name}'") from e

--- a/src/syft_rds/client/local_stores/dataset/managers/path.py
+++ b/src/syft_rds/client/local_stores/dataset/managers/path.py
@@ -4,7 +4,8 @@ from syft_core import Client as SyftBoxClient
 
 from syft_rds.client.local_stores.dataset.constants import (
     DIRECTORY_DATASETS,
-    DIRECTORY_PRIVATE,
+    DIRECTORY_PRIVATE_DATASETS,
+    DIRECTORY_PRIVATE_DATASETS_ROOT,
     DIRECTORY_PUBLIC,
 )
 
@@ -32,11 +33,20 @@ class DatasetPathManager:
         )
 
     def get_local_private_dataset_dir(self, dataset_name: str) -> Path:
-        """Get the local private directory path for a dataset."""
+        """Get local private directory for a dataset.
+
+        Returns path like: ~/.syftbox/private_datasets/<email>/<dataset_name>/
+        Private datasets (as with all other things in .syftbox) are always stored
+        locally and never synced to the SyftBox or shared with other datasites.
+        """
+        # Get .syftbox directory (parent of data_dir which is ~/SyftBox)
+        syftbox_root = self.syftbox_client.config.data_dir.parent
+
         return (
-            self.syftbox_client.my_datasite
-            / DIRECTORY_PRIVATE
-            / DIRECTORY_DATASETS
+            syftbox_root
+            / DIRECTORY_PRIVATE_DATASETS_ROOT
+            / DIRECTORY_PRIVATE_DATASETS
+            / self.syftbox_client.email
             / dataset_name
         )
 

--- a/src/syft_rds/client/local_stores/dataset/managers/schema.py
+++ b/src/syft_rds/client/local_stores/dataset/managers/schema.py
@@ -34,11 +34,12 @@ class DatasetSchemaManager:
         syftbox_client_email = self._path_manager.syftbox_client_email
 
         # Generate URLs for the dataset components
+        # Note: Don't pass source paths - URLs should point to the dataset location only
         mock_url = DatasetUrlManager.get_mock_dataset_syftbox_url(
-            syftbox_client_email, dataset_create.name, Path(dataset_create.mock_path)
+            syftbox_client_email, dataset_create.name
         )
         private_url = DatasetUrlManager.get_private_dataset_syftbox_url(
-            syftbox_client_email, dataset_create.name, Path(dataset_create.path)
+            syftbox_client_email, dataset_create.name
         )
 
         readme_url: SyftBoxURL = (

--- a/src/syft_rds/client/local_stores/dataset/managers/url.py
+++ b/src/syft_rds/client/local_stores/dataset/managers/url.py
@@ -4,7 +4,8 @@ from syft_core import SyftBoxURL
 
 from syft_rds.client.local_stores.dataset.constants import (
     DIRECTORY_DATASETS,
-    DIRECTORY_PRIVATE,
+    DIRECTORY_PRIVATE_DATASETS,
+    DIRECTORY_PRIVATE_DATASETS_ROOT,
     DIRECTORY_PUBLIC,
 )
 
@@ -25,10 +26,29 @@ class DatasetUrlManager:
     def get_private_dataset_syftbox_url(
         datasite_email: str, dataset_name: str, path: Union[Path, str] = None
     ) -> SyftBoxURL:
-        """Generate a SyftBox URL for the private dataset."""
-        return SyftBoxURL(
-            f"syft://{datasite_email}/{DIRECTORY_PRIVATE}/{DIRECTORY_DATASETS}/{dataset_name}"
+        """Generate SyftBox URL for private dataset.
+
+        NOTE: This URL is for local access only. Since private datasets are
+        stored outside the datasites folder, they are NOT accessible remotely
+        through the SyftBox relay server.
+
+        Args:
+            datasite_email: Owner's email address
+            dataset_name: Name of the dataset
+            path: Optional path within the dataset
+
+        Returns:
+            SyftBoxURL pointing to private dataset location
+        """
+        url_path = (
+            f"{DIRECTORY_PRIVATE_DATASETS_ROOT}/{DIRECTORY_PRIVATE_DATASETS}/"
+            f"{datasite_email}/{dataset_name}"
         )
+
+        if path:
+            url_path = f"{url_path}/{path}"
+
+        return SyftBoxURL(f"syft://{datasite_email}/{url_path}")
 
     @staticmethod
     def get_readme_syftbox_url(

--- a/src/syft_rds/models/dataset_models.py
+++ b/src/syft_rds/models/dataset_models.py
@@ -69,10 +69,17 @@ class Dataset(ItemBase):
                 f"Your SyftBox email: '{self._syftbox_client.email}'. "
                 f"Host email: '{self._client.config.host}'"
             )
-
-        private_path: Path = self.private.to_local_path(
-            datasites_path=self._syftbox_client.datasites
+        # Private datasets are stored in ~/.syftbox/private_datasets/<email>/<dataset-name>
+        # Use the same logic as DatasetPathManager.get_local_private_dataset_dir()
+        home_dir = self._syftbox_client.config.data_dir.parent
+        private_path = (
+            home_dir
+            / ".syftbox"
+            / "private_datasets"
+            / self._syftbox_client.email
+            / self.name
         )
+
         if not private_path.exists():
             raise FileNotFoundError(
                 f"Private data not found at {private_path}. "

--- a/tests/unit/dataset_paths_test.py
+++ b/tests/unit/dataset_paths_test.py
@@ -1,0 +1,144 @@
+"""Integration tests for private dataset path structure (v0.5.0)."""
+
+from syft_core import SyftClientConfig
+from syft_rds.client.rds_client import RDSClient, init_session
+from tests.utils import create_dataset
+
+
+def test_private_dataset_stored_outside_datasites(
+    do_syftbox_config: SyftClientConfig,
+) -> None:
+    """Verify private datasets are stored outside the datasites folder."""
+    do_rds_client: RDSClient = init_session(
+        host=do_syftbox_config.email,
+        email=do_syftbox_config.email,
+        syftbox_client_config_path=do_syftbox_config.path,
+        start_syft_event_server=False,
+    )
+    assert do_rds_client.is_admin
+
+    # Create a dataset
+    dataset = create_dataset(do_rds_client, "PathTestDataset")
+
+    # Get the private path
+    private_path = dataset.get_private_path()
+
+    # Verify it's in .syftbox/private_datasets, NOT in datasites
+    assert ".syftbox" in str(private_path)
+    assert "private_datasets" in str(private_path)
+    assert "datasites" not in str(private_path)
+    assert private_path.exists()
+
+    # Verify the actual directory structure
+    # Expected: ~/.syftbox/private_datasets/<email>/<dataset-name>/
+    path_parts = private_path.parts
+    assert ".syftbox" in path_parts
+    assert "private_datasets" in path_parts
+    assert do_syftbox_config.email in path_parts
+    assert "PathTestDataset" in path_parts
+
+
+def test_private_and_mock_paths_separated(
+    do_syftbox_config: SyftClientConfig,
+) -> None:
+    """Verify private and mock datasets are in completely separate locations."""
+    do_rds_client: RDSClient = init_session(
+        host=do_syftbox_config.email,
+        email=do_syftbox_config.email,
+        syftbox_client_config_path=do_syftbox_config.path,
+        start_syft_event_server=False,
+    )
+    assert do_rds_client.is_admin
+
+    dataset = create_dataset(do_rds_client, "SeparationTest")
+
+    private_path = dataset.get_private_path()
+    mock_path = dataset.get_mock_path()
+
+    # Paths should be completely different
+    assert private_path != mock_path
+    assert private_path.parent != mock_path.parent
+
+    # Mock should be in datasites folder (synced)
+    assert "datasites" in str(mock_path)
+    assert "public" in str(mock_path)
+    assert "datasets" in str(mock_path)
+
+    # Private should be outside datasites (not synced)
+    assert "datasites" not in str(private_path)
+    assert ".syftbox/private_datasets" in str(private_path)
+
+    # Both should exist
+    assert private_path.exists()
+    assert mock_path.exists()
+
+
+def test_private_dataset_url_format(do_syftbox_config: SyftClientConfig) -> None:
+    """Verify private and mock dataset URLs have correct format."""
+    do_rds_client: RDSClient = init_session(
+        host=do_syftbox_config.email,
+        email=do_syftbox_config.email,
+        syftbox_client_config_path=do_syftbox_config.path,
+        start_syft_event_server=False,
+    )
+    assert do_rds_client.is_admin
+
+    dataset = create_dataset(do_rds_client, "URLTest")
+
+    # Check private URL format
+    private_url = str(dataset.private)
+    assert f"syft://{do_syftbox_config.email}" in private_url
+    assert ".syftbox/private_datasets" in private_url
+    assert f"{do_syftbox_config.email}/URLTest" in private_url
+
+    # Check mock URL format
+    mock_url = str(dataset.mock)
+    assert f"syft://{do_syftbox_config.email}" in mock_url
+    assert "public/datasets/URLTest" in mock_url
+    # Should NOT have extra path segments
+    assert "/private/" not in mock_url
+
+
+def test_multi_user_private_path_isolation(
+    do_syftbox_config: SyftClientConfig, ds_syftbox_config: SyftClientConfig
+) -> None:
+    """Verify different users get isolated private dataset directories."""
+    # Create DO client
+    do_rds_client: RDSClient = init_session(
+        host=do_syftbox_config.email,
+        email=do_syftbox_config.email,
+        syftbox_client_config_path=do_syftbox_config.path,
+        start_syft_event_server=False,
+    )
+    assert do_rds_client.is_admin
+
+    # Create DS client (simulating a second data owner on same machine)
+    ds_rds_client: RDSClient = init_session(
+        host=ds_syftbox_config.email,
+        email=ds_syftbox_config.email,
+        syftbox_client_config_path=ds_syftbox_config.path,
+        start_syft_event_server=False,
+    )
+    assert ds_rds_client.is_admin
+
+    # Both create datasets with same name
+    do_dataset = create_dataset(do_rds_client, "SharedName")
+    ds_dataset = create_dataset(ds_rds_client, "SharedName")
+
+    # Get private paths
+    do_private_path = do_dataset.get_private_path()
+    ds_private_path = ds_dataset.get_private_path()
+
+    # Paths should be different
+    assert do_private_path != ds_private_path
+
+    # Each should contain their respective email
+    assert do_syftbox_config.email in str(do_private_path)
+    assert ds_syftbox_config.email in str(ds_private_path)
+
+    # Both should exist
+    assert do_private_path.exists()
+    assert ds_private_path.exists()
+
+    # Verify data doesn't overlap
+    assert do_private_path.parent != ds_private_path.parent

--- a/uv.lock
+++ b/uv.lock
@@ -3021,7 +3021,7 @@ wheels = [
 
 [[package]]
 name = "syft-rds"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
**Private datasets** are stored in `~/.syftbox/private_datasets/<email>/<dataset-name>/` and are **NEVER synced** to the SyftBox relay server. This ensures true client-side privacy - your private data never leaves your machine.

**Mock (public) datasets** are stored in `~/SyftBox/datasites/<email>/public/datasets/` and **ARE synced** to the relay server, allowing other users to explore your dataset structure and submit job requests.

```
~/.syftbox/  # Everything inside .syftbox never gets shared with anyone
  private_datasets/
    your-email@example.com/
      my-dataset/           # Your private data (NEVER synced anywhere)
        data.csv
        ...

~/SyftBox/
  datasites/
    your-email@example.com/
      public/
        datasets/
          my-dataset/         # Your mock data (synced to the SyftBox server and other datasites)
            mock_data.csv
            README.md
```